### PR TITLE
special case: wrap statement lists in block statements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "shift-shrink",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shift-shrink",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Test case reducer for Shift-format JS ASTs",
   "author": "Shape Security",
   "homepage": "https://github.com/shapesecurity/shift-shrink-js",

--- a/test/subtrees.js
+++ b/test/subtrees.js
@@ -6,9 +6,13 @@ let { parseScript } = require('shift-parser');
 let { default: codeGen } = require('shift-codegen');
 let { subtrees } = require('..');
 
-test('subtrees', t => {
-  let actual = [...subtrees(parseScript('console.log(x + y);'))]
+function allSubtrees(src) {
+  return [...subtrees(parseScript(src))]
     .map(tree => codeGen(tree));
+}
+
+test('subtrees', t => {
+  let actual = allSubtrees('console.log(x + y);');
   let expected = [
     '',
     ';',
@@ -27,4 +31,15 @@ test('subtrees', t => {
     'console.log(x+null)',
   ];
   t.deepEqual(expected, actual);
+});
+
+test('subtrees with blocks', t => {
+  let all = allSubtrees('try { foo; bar; } catch (e) { }');
+  t.true(all.includes('{foo;bar}'));
+
+  all = allSubtrees('switch (0) { case x: foo; bar; }');
+  t.true(all.includes('{foo;bar}'));
+
+  all = allSubtrees('function f() { foo; bar; }');
+  t.true(all.includes('{foo;bar}'));
 });


### PR DESCRIPTION
This allows `{ foo; bar; }` to be considered a subtree of `try { foo; bar; } catch (e) { }`, which requires synthesizing a new BlockStatement. 

Includes version bump commit, so please **rebase**, not squash.