### PR TITLE
quiet warnings in CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -31,7 +31,7 @@ jobs:
         run: npm run build
 
       - name: Lint
-        run: npm run lint
+        run: npm run lint -- --quiet
 
       - name: Test
         run: npm test


### PR DESCRIPTION
So the github actions annotations garbage doesn't pollute all PRs.