### PR TITLE
add publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,26 @@
+name: publish
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Publish
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_FOR_SHAPESECURITY_USER }}


### PR DESCRIPTION
Based on (i.e. almost identical to, just with a different secret name and with updated actions) the [action for ecmarkup](https://github.com/tc39/ecmarkup/blob/65103eeb00d2b060c6ca178314bd0613cd0d108c/.github/workflows/publish.yml).

Once this lands I'll land https://github.com/shapesecurity/shift-shrink-js/pull/12 and publish it to confirm it all works.